### PR TITLE
Atualiza ProgramadorPleno.md - remove SRP and DIP

### DIFF
--- a/ProgramadorPleno.md
+++ b/ProgramadorPleno.md
@@ -36,8 +36,7 @@ content­type, encoding, etc).
 	- Composite;
 	- Strategy;
 	- State.
-- Codifica seguindo ao menos KISS (keep it simple, stupid), DRY (don't repeat yourself),
-SRP (single responsability principle) e DIP (dependency inversion principle);
+- Codifica seguindo ao menos KISS (keep it simple, stupid), DRY (don't repeat yourself);
 - Possui entendimento básico e aplica as regras de clean code e object calisthenics;
 - Conhecimento de arquitetura de software, princípios SOLID e refatoração;
 - Conhecimento e compreensão da motivação do gerenciamento de assets (otimização de imagens, minificação, concatenação, cache busting);


### PR DESCRIPTION
Eu acho que não é necessário especificar na linha 39 o SRP e o DIP, pois há um tópico que solicita conhecimento em SOLID, onde SRP e DIP são uma das letras do acrônimo.
