### PR TITLE
Ajustes em títulos: espaço depois do jogo da velha (#)

### DIFF
--- a/EstagiarioProgramacao.md
+++ b/EstagiarioProgramacao.md
@@ -1,19 +1,19 @@
-#Estagiário PHP
+# Estagiário PHP
 
-##Responsabilidades
+## Responsabilidades
 
 O estagiário tem como responsabilidade a busca de aprendizado e experiência prática.
 
-##Requisitos
+## Requisitos
 
 - Conceitos básicos de lógica de programação;
 - Conceitos básicos de HTML;
 
-#Desejável
+# Desejável
 
 - Conhecimentos básicos da sintaxe PHP;
 
-#Perfil esperado
+# Perfil esperado
 
 - Sedento por conhecimento ao extremo (sempre pesquisando e perguntando);
 - Bom relacionamento com os colegas;

--- a/ProgramadorJunior.md
+++ b/ProgramadorJunior.md
@@ -1,11 +1,11 @@
-#Programador PHP Junior
+# Programador PHP Junior
 
-##Responsabilidades
+## Responsabilidades
 
 É um desenvolvedor em início de carreira, acabou de sair da faculdade (ou está ainda cursando) e não tem experiência comprovada no desenvolvimento de software dentro de uma empresa.
 Seu foco de atuação é no desenvolvimento de cada unidade de um software, e para isso deve receber as especificações completas dos problemas, contendo: entradas, comportamentos esperados e saídas.
 
-##Requisitos
+## Requisitos
 
 - Funcionamento e uso das estruturas básicas de programação (if, else, else if, for, foreach, while, do/while, switch);
 - Conceitos básicos de orientação à objetos (objeto, classe, método, abstração, polimorfismo);
@@ -34,11 +34,11 @@ Seu foco de atuação é no desenvolvimento de cada unidade de um software, e pa
 - Conhecimento básico do uso do git (checkout, pull, commit, push, add, reset);
 - Conhece e utiliza ao menos a PSR­0
 
-#Desejável
+# Desejável
 
 - Conhecimentos básicos de algum framework MVC
 
-#Perfil esperado
+# Perfil esperado
 
 - Sedento por conhecimento ao extremo (sempre pesquisando e perguntando);
 - Organizado;

--- a/ProgramadorPleno.md
+++ b/ProgramadorPleno.md
@@ -1,10 +1,10 @@
-#Programador PHP Pleno
+# Programador PHP Pleno
 
-##Responsabilidades
+## Responsabilidades
 
 Desenvolvedor com experiência um pouco mais consolidada no desenvolvimento de software. Seu foco de atuação é na análise e desenvolvimento das funcionalidades dos software, sugerindo melhorias no processo e auxiliando os programadores junior e estagiários sempre que houver possibilidade/necessidade.
 
-##Requisitos
+## Requisitos
 
 - Todas as do Programador PHP Junior, porém com maior desenvoltura (qualidade, produtividade e autonomia);
 - Domina os diagramas de classe e sequência da UML;
@@ -12,7 +12,7 @@ Desenvolvedor com experiência um pouco mais consolidada no desenvolvimento de s
 	- Utilização correta dos métodos (ao menos OPTIONS, GET, POST, PUT e DELETE);
 	- Utilização correta dos status codes (envio e recebimento);
 	- Negociação de conteúdo através dos headers de requisição (language,
-content­type, encoding, etc). 
+content­type, encoding, etc).
 - Utilização avançada de bancos de dados relacionais
 	- Gerenciamento de schemas;
 	- Gerenciamento de permissões;
@@ -49,17 +49,17 @@ e suas recomendações (PSRs)
 cherry­pick);
 	- Gerenciamento de branchs para desenvolvimento em equipe;
 - Consegue analisar um problema, pensando nas necessidades a serem contempladas
-computacionalmente, trazendo soluções viáveis; 
+computacionalmente, trazendo soluções viáveis;
 - Conhecimento sobre Cloud Computing (IaaS, PaaS e SaaS);
 - Conhece o manifesto ágil e seus princípios, e entende os papéis definidos pelo SCRUM
 
 
-#Desejável
+# Desejável
 
 - Conhecimentos avançados de algum framework MVC
 - Conhecimentos em bancos de dados NoSQL
 
-#Perfil esperado
+# Perfil esperado
 
 - Disciplina e organização é fundamental;
 - Sedento por conhecimento;
@@ -68,4 +68,3 @@ desenvolvimento;
 - Pesquisador nas horas vagas, trazendo novidades que podem ser realmente aplicadas nos projetos;
 - Senso crítico;
 - Engajamento com a equipe, para crescimento sustentável de todos.
-

--- a/ProgramadorSenior.md
+++ b/ProgramadorSenior.md
@@ -1,10 +1,10 @@
-#Programador PHP Sênior
+# Programador PHP Sênior
 
-##Responsabilidades
+## Responsabilidades
 
 Desenvolvedor com habilidades extremamente evoluídas em todas as etapas do desenvolvimento de software e na priorização correta das demandas existentes e alta capacidade de entrega.
 
-##Requisitos
+## Requisitos
 
 - Todas as do Programador PHP Pleno, porém com maior desenvoltura (qualidade, produtividade e autonomia);
 - Conhecimento sobre o funcionamento interno de um framework e qual a motivação de sua utilização sabendo identificar seus componentes e suas funcionalidades;
@@ -14,8 +14,7 @@ Desenvolvedor com habilidades extremamente evoluídas em todas as etapas do dese
 - Conhecimento sobre CGI, FastCGI e mod_php;
 - Conhecimento sobre escalabilidade;
 
-#Desejável
+# Desejável
 
 
-#Perfil esperado
-
+# Perfil esperado


### PR DESCRIPTION
Os títulos não estavam funcionando por erro na escrita do markdown:

![captura de tela de 2017-04-28 15 57 29](https://cloud.githubusercontent.com/assets/12635603/25543484/1baa5ab6-2c2d-11e7-95f8-6b69247d3f0d.png)
