### PR TITLE
Criptografia

### DIFF
--- a/ProgramadorPleno.md
+++ b/ProgramadorPleno.md
@@ -21,8 +21,10 @@ content­type, encoding, etc).
 - Conhecimento intermediário sobre sistemas operacionais (processos, redes, estruturas de diretórios e configurações básicas) e linha de comando. Comandos como `ps`, `kill`, `ifconfig`, `nmap`, `hostname`, `find`, `grep`, `>`, `>>`, `|`, `&`, `su`, `sudo`, `wget`, `crontab`;
 - Conhecimento básico de segurança e criptografia de dados
 	- SSL;
-	- Geração de hash utilizando salt (HMAC);
-	- Algoritmos de criptografia (DES, 3DES, etc).
+	- Resumo (SHA-2, SHA-3, Blake2...);
+	- MAC (HMAC, GMAC, OMAC, Poly1305...);
+	- Derivação de chave (BCrypt, Argon2i, PBKDF2, SCrypt...);
+	- Encriptação simétrica (3DES, AES, ChaCha20, Salsa20...).
 - Codificar a segurança da aplicação de acordo com as especificações fornecidas por especialistas em segurança de TI.
 - Sabe fazer as tarefas de debug e profile usando o xdebug ou zend debugger com o objetivo de localizar erros e otimizar os códigos;
 - Conhece os design patterns básicos


### PR DESCRIPTION
O HMAC não usa **salt**, ele usa uma **chave**. As chaves são secretas, já o salt não. Dizer "Geração de hash utilizando salt (HMAC)" é ao menos um erro, o HMAC não tem salt, ela é um Keyed-Hash. 

O salt é aplicado em derivações de chaves, como PBKDF2, BCrypt, Argon2i, SCrypt, Lyra2, e também em outros propósitos, como na própria encriptação simétrica e assimétrica.  Acredito que o que quis dizer seja derivações de chaves, uma vez que PBKDF2 usa HMAC, por exemplo.

Acredito que com essa alteração isso faça mais sentido.